### PR TITLE
Configuring cache memory usage from Django end 

### DIFF
--- a/src/etools_datamart/config/settings.py
+++ b/src/etools_datamart/config/settings.py
@@ -221,6 +221,8 @@ AUTHENTICATION_BACKENDS = [
 ]
 MYSTICA_PASSWORD = env("MYSTICA_PASSWORD")
 
+env.cache()["OPTIONS"]["TIMEOUT"] = 600
+
 CACHES = {
     "default": env.cache(),
     "lock": env.cache("CACHE_URL_LOCK"),


### PR DESCRIPTION
Configuring cache memory usage from Django end by setting TIMEOUT for  created  cached item
-  to  avoid memory build up 