### PR TITLE
[e37524]: Handle scenario when no disaggregation exists for ReportsAppliedindicator 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+4.7
+----
+* Fix missing record issue fue to the case PDIndicator loader when where is no 
+  ReportsDisaggragation for a given ReportsAppliedindicator record. 
+
 4.6
 ----
 * First phase of reducing sql queries in etl loaders to reduce execution time

--- a/src/etools_datamart/__init__.py
+++ b/src/etools_datamart/__init__.py
@@ -1,3 +1,3 @@
 NAME = "etools-datamart"
-VERSION = __version__ = "4.6"
+VERSION = __version__ = "4.7"
 __author__ = ""

--- a/src/etools_datamart/apps/mart/data/models/pd_indicator.py
+++ b/src/etools_datamart/apps/mart/data/models/pd_indicator.py
@@ -163,7 +163,7 @@ class PDIndicator(LocationMixin, EtoolsDataMartModel):
             schema_name=loader.context["country"].schema_name,
             source_id=record.pk,
             source_location_id=record.location.pk,
-            source_disaggregation_id=record.disaggregation.pk if record.disaggregation else record.disaggregation,
+            source_disaggregation_id=record.disaggregation.pk if record.disaggregation else None,
         )
 
         mapping = add_location_mapping(

--- a/src/etools_datamart/apps/mart/data/models/pd_indicator.py
+++ b/src/etools_datamart/apps/mart/data/models/pd_indicator.py
@@ -62,14 +62,12 @@ class PDIndicatorLoader(EtoolsLoader):
     def get_disaggregation_name(self, record: ReportsAppliedindicator, values: dict, **kwargs):
         if record.disaggregation:
             return record.disaggregation.name
-        else:
-            return ""
+        return ""
 
     def get_disaggregation_active(self, record: ReportsAppliedindicator, values: dict, **kwargs):
         if record.disaggregation:
             return record.disaggregation.active
-        else:
-            return False
+        return False
 
 
 class PDIndicator(LocationMixin, EtoolsDataMartModel):

--- a/src/etools_datamart/apps/mart/data/models/pd_indicator.py
+++ b/src/etools_datamart/apps/mart/data/models/pd_indicator.py
@@ -36,20 +36,42 @@ class PDIndicatorLoader(EtoolsLoader):
         for page_idx in paginator.page_range:
             page = paginator.page(page_idx)
             for indicator in page.object_list:
-                for disaggregation in indicator.disaggregations.all():
-                    indicator.disaggregation = disaggregation
+                all_disaggregations = indicator.disaggregations.all()
+                if 0 == len(all_disaggregations):
                     for location in indicator.locations.all():
+                        indicator.disaggregation = None
                         indicator.location = location
                         filters = self.config.key(self, indicator)
                         values = self.get_values(indicator)
                         op = self.process_record(filters, values)
                         self.increment_counter(op)
+                else:
+                    for disaggregation in all_disaggregations:
+                        indicator.disaggregation = disaggregation
+                        for location in indicator.locations.all():
+                            indicator.location = location
+                            filters = self.config.key(self, indicator)
+                            values = self.get_values(indicator)
+                            op = self.process_record(filters, values)
+                            self.increment_counter(op)
 
     def get_pd_url(self, record: ReportsAppliedindicator, values: dict, **kwargs):
         return reverse(
             "api:intervention-detail",
             args=["latest", record.lower_result.result_link.intervention.pk],
         )
+
+    def get_disaggregation_name(self, record: ReportsAppliedindicator, values: dict, **kwargs):
+        if record.disaggregation:
+            return record.disaggregation.name
+        else:
+            return ""
+
+    def get_disaggregation_active(self, record: ReportsAppliedindicator, values: dict, **kwargs):
+        if record.disaggregation:
+            return record.disaggregation.active
+        else:
+            return False
 
 
 class PDIndicator(LocationMixin, EtoolsDataMartModel):
@@ -133,13 +155,14 @@ class PDIndicator(LocationMixin, EtoolsDataMartModel):
 
     class Options:
         source = ReportsAppliedindicator
-        queryset = ReportsAppliedindicator.objects.select_related("indicator", "section").all
+        queryset = ReportsAppliedindicator.objects.select_related
+        ("indicator", "section")
 
         key = lambda loader, record: dict(
             schema_name=loader.context["country"].schema_name,
             source_id=record.pk,
             source_location_id=record.location.pk,
-            source_disaggregation_id=record.disaggregation.pk,
+            source_disaggregation_id=record.disaggregation.pk if record.disaggregation else record.disaggregation,
         )
 
         mapping = add_location_mapping(
@@ -156,8 +179,8 @@ class PDIndicator(LocationMixin, EtoolsDataMartModel):
                 result_link_intervention="lower_result.result_link.intervention.pk",
                 pd_reference_number="lower_result.result_link.intervention.reference_number",
                 pd_url="-",
-                disaggregation_name="disaggregation.name",
-                disaggregation_active="disaggregation.active",
+                disaggregation_name="-",
+                disaggregation_active="-",
                 location_name="location.name",
                 location_pcode="location.p_code",
                 location_level="location.admin_level",


### PR DESCRIPTION
Problem:
When ReportsAppliedindicator in etools db  does not have any ReportsDisaggregation then the 
the loop in custom process_country method PDIndicator loader can't  load combinations for  
(indicator, disaggregation, location). 
 
Fix: 
When no  ReportsDisaggregation case  is , detected,  it is assumed to be empty and it is used 
for generation of combinations.    
