### PR TITLE
[ch38091] delete records at country level in the target table

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+4.7.2
+----
+* Loader logic has been modified to delete records at country level in the target table when truncate option 
+  is enabled.  
+
 4.7.1
 ----
 * ExportAccessLog model and its usage changed. The export access logs include  username now.

--- a/src/etools_datamart/__init__.py
+++ b/src/etools_datamart/__init__.py
@@ -1,3 +1,3 @@
 NAME = "etools-datamart"
-VERSION = __version__ = "4.7.1"
+VERSION = __version__ = "4.7.2"
 __author__ = ""


### PR DESCRIPTION
ETL loader generic logic used to have a single transaction covering all countries.  
We had changed this logic so that transaction would be at country level. But when 
truncate was enabled for the ETL loader it was still deleting all the records rather  
than just country related records.   

We  have fixed this issue by making delete records logic applied at country level
when truncate option is enabled for the loader.     