### PR TITLE
[ch33585] Fix intermittent disappearance of country and record count information in RUNNING status for ETL loaders

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+4.7.5
+----
+* By extendin the expiry of cache that stores the etl country state and count, we get state and count info 
+  along with RUNNING status. 
+
 4.7.4
 ----
 * EtoolsUser endpoint filtering by groups 

--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 4.7.5
 ----
-* By extendin the expiry of cache that stores the etl country state and count, we get state and count info 
-  along with RUNNING status. 
+* Stage(country) and record count info along with RUNNING status are made available by extendin the expiry of the 
+  cache entry that stores the etl country and count. 
 
 4.7.4
 ----

--- a/src/etools_datamart/__init__.py
+++ b/src/etools_datamart/__init__.py
@@ -1,3 +1,3 @@
 NAME = "etools-datamart"
-VERSION = __version__ = "4.7.4"
+VERSION = __version__ = "4.7.5"
 __author__ = ""

--- a/src/etools_datamart/apps/mart/data/loader.py
+++ b/src/etools_datamart/apps/mart/data/loader.py
@@ -250,7 +250,11 @@ class EtoolsLoader(BaseLoader):
                         if not getattr(self, "TRANSACTION_BY_BATCH", False):
                             sid = transaction.savepoint()
 
-                        cache.set("STATUS:%s" % self.etl_task.task, "%s - %s" % (country, self.results.processed))
+                        cache.set(
+                            "STATUS:%s" % self.etl_task.task,
+                            "%s - %s" % (country, self.results.processed),
+                            timeout=10 * 60 * 60,
+                        )
                         self.context["country"] = country
 
                         if stdout and verbosity > 0:
@@ -314,7 +318,7 @@ class EtoolsLoader(BaseLoader):
             raise
         else:
             self.on_end(None)
-            cache.set("STATUS:%s" % self.etl_task.task, "completed - %s" % self.results.processed)
+            cache.set("STATUS:%s" % self.etl_task.task, "completed - %s" % self.results.processed, timeout=5 * 60)
         finally:
             if lock:  # pragma: no branch
                 try:

--- a/src/etools_datamart/apps/mart/data/loader.py
+++ b/src/etools_datamart/apps/mart/data/loader.py
@@ -33,6 +33,9 @@ class EToolsLoaderOptions(BaseLoaderOptions):
 
 
 class EtoolsLoader(BaseLoader):
+
+    status_info_expiry = 10 * 60 * 60
+
     def get_mart_values(self, record=None):
         country = self.context["country"]
         ret = {
@@ -253,7 +256,7 @@ class EtoolsLoader(BaseLoader):
                         cache.set(
                             "STATUS:%s" % self.etl_task.task,
                             "%s - %s" % (country, self.results.processed),
-                            timeout=10 * 60 * 60,
+                            timeout=EtoolsLoader.status_info_expiry,
                         )
                         self.context["country"] = country
 
@@ -318,7 +321,11 @@ class EtoolsLoader(BaseLoader):
             raise
         else:
             self.on_end(None)
-            cache.set("STATUS:%s" % self.etl_task.task, "completed - %s" % self.results.processed, timeout=5 * 60)
+            cache.set(
+                "STATUS:%s" % self.etl_task.task,
+                "completed - %s" % self.results.processed,
+                timeout=EtoolsLoader.status_info_expiry,
+            )
         finally:
             if lock:  # pragma: no branch
                 try:


### PR DESCRIPTION
Problem:
The expiry period for the cache entry for etl tasks' additional information for RUNNING status  was default.
This period was not long enough for long running loaders.  
Solution:
The expiry period has been extended to make sure that  cache entry is not evicted quickly.


 