### PR TITLE
[ch38966]:Extract latitide and longitude from point and geom fields if they hapen to be null

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+4.7.13
+----
+* Improved FMQuestion and FMOntrack loaders to extract latitude and longitude from 
+Location.point when Location.longitude and Location.latitude.
+
 4.7.12
 ----
 Formula for SpotCheckFindings.pending_unsupported_amount has been updated as below;

--- a/src/etools_datamart/__init__.py
+++ b/src/etools_datamart/__init__.py
@@ -1,3 +1,3 @@
 NAME = "etools-datamart"
-VERSION = __version__ = "4.7.12"
+VERSION = __version__ = "4.7.13"
 __author__ = ""

--- a/src/etools_datamart/apps/mart/data/models/fm_questions.py
+++ b/src/etools_datamart/apps/mart/data/models/fm_questions.py
@@ -25,6 +25,28 @@ from etools_datamart.apps.sources.etools.models import (
 logger = get_task_logger(__name__)
 
 
+def extract_latitude(location):
+    if location.latitude is not None:
+        return location.latitude
+    elif location.point is not None:
+        return location.point.y
+    elif location.geom is not None:
+        return location.centroid.y
+    else:
+        return None
+
+
+def extract_longitude(location):
+    if location.longitude is not None:
+        return location.latitude
+    elif location.point is not None:
+        return location.point.x
+    elif location.geom is not None:
+        return location.centroid.x
+    else:
+        return None
+
+
 class FMQuestionLoader(EtoolsLoader):
     """Loader for FM Questions"""
 
@@ -244,8 +266,8 @@ class FMQuestionLoader(EtoolsLoader):
                 "admin_level": instance.admin_level,
                 "source_id": instance.source_id,
                 "location_type": instance.admin_level_name,
-                "latitude": instance.latitude,
-                "longitude": instance.longitude,
+                "latitude": extract_latitude(instance),
+                "longitude": extract_longitude(instance),
             }
         except Location.DoesNotExist:
             return {key: "N/A" for key in loc_fields}
@@ -486,8 +508,8 @@ class FMOntrackLoader(EtoolsLoader):
                 "admin_level": instance.admin_level,
                 "source_id": instance.source_id,
                 "location_type": instance.admin_level_name,
-                "latitude": instance.latitude,
-                "longitude": instance.longitude,
+                "latitude": extract_latitude(instance),
+                "longitude": extract_longitude(instance),
             }
         except Location.DoesNotExist:
             return {key: "N/A" for key in loc_fields}


### PR DESCRIPTION
Issue:  ch38966  Lat/Lng columns are null for FM-Ontrack endpoint for certain countries 

Fixed by updating  FM-Ontrack and FMQuestion loaders to extract Extract latitide and longitude from point and geom fields if they happen to be null

